### PR TITLE
Update Dockerfile to Ubuntu 22.04 as 18.04 is EOL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,18 @@
-FROM ubuntu:18.04 as build
+FROM ubuntu:22.04 as build
 
 RUN apt-get update && \
     apt-get install -y \
         binutils-mips-linux-gnu \
-        bsdmainutils \
+        bsdextrautils \
         build-essential \
         git \
         libsdl2-dev \
-        pkg-config \
-        python3 \
-        wget
+        pkgconf \
+        python3
 
-RUN mkdir /sm64
-WORKDIR /sm64
-ENV PATH="/sm64/tools:${PATH}"
+RUN mkdir /sm64ex-alo
+WORKDIR /sm64ex-alo
+ENV PATH="/sm64ex-alo/tools:${PATH}"
 
-CMD echo 'usage: docker run --rm --mount type=bind,source="$(pwd)",destination=/sm64 sm64 make VERSION=us -j4\n' \
-         'see https://github.com/n64decomp/sm64/blob/master/README.md for advanced usage'
+CMD echo 'Usage: docker run --rm -v ${PWD}:/sm64ex-alo sm64ex-alo make VERSION=us -j4\n' \
+         'See https://github.com/AloUltraExt/sm64ex-alo/blob/master/README.md for more information'

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Fork of [sm64pc/sm64ex](https://github.com/sm64pc/sm64ex) with additional featur
 
   #### Install build dependencies:
   ```sh
-  sudo apt install -y binutils-mips-linux-gnu build-essential git libcapstone-dev pkgconf python3 gcc-mips-linux-gnu
+  sudo apt install -y binutils-mips-linux-gnu build-essential git pkgconf python3 gcc-mips-linux-gnu
   ```
 
   #### Build:


### PR DESCRIPTION
also:

- Fix outdated packages in Dockerfile
- Fix outdated package in readme

Related pull for sm64ex: https://github.com/sm64pc/sm64ex/pull/538

Related pull for original decomp: https://github.com/n64decomp/sm64/pull/91