### PR TITLE
[Wii U] buildfix for current wut

### DIFF
--- a/Dockerfile.wiiu
+++ b/Dockerfile.wiiu
@@ -1,0 +1,7 @@
+FROM devkitpro/devkitppc:20240702
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential
+
+WORKDIR sm64ex-alo

--- a/README.md
+++ b/README.md
@@ -110,5 +110,12 @@ Fork of [sm64pc/sm64ex](https://github.com/sm64pc/sm64ex) with additional featur
 
  * To build for sm64ex platforms, [click here](https://github.com/sm64pc/sm64ex/blob/nightly/README.md).
  * To build for Wii U, [click here](https://github.com/aboood40091/sm64-port/blob/master/README.md). (TARGET_WII_U=1)
+   * Alternatively, use the included `Dockerfile.wiiu` as follows:
+     * create the Docker image (only necessary once)
+       * `docker build -f Dockerfile.wiiu . -t alou-builder`
+     * compile
+       * `docker run -it --rm -v %CD%:/sm64ex-alo alou-builder make TARGET_WII_U=1`
+     * clean
+       * `docker run -it --rm -v %CD%:/sm64ex-alo alou-builder make TARGET_WII_U=1 clean`
  * To build for 3DS, [click here](https://github.com/sm64-port/sm64_3ds/blob/master/README.md). (TARGET_N3DS=1)
  * To build for Switch, [click here](https://github.com/fgsfdsfgs/sm64ex/blob/switch/README.md). (TARGET_SWITCH=1)

--- a/include/PR/os_time.h
+++ b/include/PR/os_time.h
@@ -49,7 +49,7 @@ extern "C" {
 /*
  * Structure for time value
  */
-typedef u64	OSTime;
+typedef u64	OSTime64;
 
 /*
  * Structure for interval timer
@@ -57,8 +57,8 @@ typedef u64	OSTime;
 typedef struct OSTimer_s {
 	struct OSTimer_s	*next;	/* point to next timer in list */
 	struct OSTimer_s	*prev;	/* point to previous timer in list */
-	OSTime			interval;	/* duration set by user */
-	OSTime			value;		/* time remaining before */
+	OSTime64			interval;	/* duration set by user */
+	OSTime64			value;		/* time remaining before */
 						/* timer fires           */
 	OSMesgQueue		*mq;		/* Message Queue */
 	OSMesg			msg;		/* Message to send */
@@ -98,9 +98,9 @@ typedef struct OSTimer_s {
 
 /* Timer interface */
 
-extern OSTime		osGetTime(void);
-extern void		osSetTime(OSTime);
-extern u32		osSetTimer(OSTimer *, OSTime, OSTime, OSMesgQueue *, OSMesg);
+extern OSTime64	osGetTime(void);
+extern void		osSetTime(OSTime64);
+extern u32		osSetTimer(OSTimer *, OSTime64, OSTime64, OSMesgQueue *, OSMesg);
 extern int		osStopTimer(OSTimer *);
 
 

--- a/src/game/profiler.c
+++ b/src/game/profiler.c
@@ -59,7 +59,7 @@ void profiler_log_vblank_time(void) {
 }
 
 // draw the specified profiler given the information passed.
-void draw_profiler_bar(OSTime clockBase, OSTime clockStart, OSTime clockEnd, s16 posY, u16 color) {
+void draw_profiler_bar(OSTime64 clockBase, OSTime64 clockStart, OSTime64 clockEnd, s16 posY, u16 color) {
     s64 durationStart, durationEnd;
     s32 rectX1, rectX2;
 
@@ -139,7 +139,7 @@ void draw_reference_profiler_bars(void) {
 void draw_profiler_mode_1(void) {
     s32 i;
     struct ProfilerFrameData *profiler;
-    OSTime clockBase;
+    OSTime64 clockBase;
 
     // the profiler logs 2 frames of data: last frame and current frame. Indexes are used
     // to keep track of the current frame, so the index is xor'd to retrieve the last frame's

--- a/src/game/profiler.h
+++ b/src/game/profiler.h
@@ -17,14 +17,14 @@ struct ProfilerFrameData {
     // 2: render
     // 3: display lists
     // 4: thread 4 end (0 terminated)
-    /* 0x08 */ OSTime gameTimes[5];
+    /* 0x08 */ OSTime64 gameTimes[5];
     // gfxTimes:
     // 0: processors queued
     // 1: rsp completed
     // 2: rdp completed
-    /* 0x30 */ OSTime gfxTimes[3];
-    /* 0x48 */ OSTime soundTimes[8];
-    /* 0x88 */ OSTime vblankTimes[8];
+    /* 0x30 */ OSTime64 gfxTimes[3];
+    /* 0x48 */ OSTime64 soundTimes[8];
+    /* 0x88 */ OSTime64 vblankTimes[8];
 };
 
 // thread event IDs

--- a/src/pc/controller/controller_wiiu.c
+++ b/src/pc/controller/controller_wiiu.c
@@ -135,8 +135,8 @@ static void read_wpad(OSContPad* pad) {
     bool gamepadRightStickNotSet = pad->ext_stick_x == 0 && pad->ext_stick_y == 0;
 
     if (status.extensionType == WPAD_EXT_NUNCHUK || status.extensionType == WPAD_EXT_MPLUS_NUNCHUK) {
-        uint32_t ext = status.nunchuck.hold;
-        stick = status.nunchuck.stick;
+        uint32_t ext = status.nunchuk.hold;
+        stick = status.nunchuk.stick;
         rStick = (KPADVec2D) {0.0, 0.0};
 
         if (wm & WPAD_BUTTON_A) pad->button |= A_BUTTON;

--- a/src/pc/gfx/gfx_gx2_window.cpp
+++ b/src/pc/gfx/gfx_gx2_window.cpp
@@ -105,13 +105,6 @@ static void gfx_gx2_window_exit_callback(void)
     _Exit(-1);
 }
 
-typedef enum _GX2AspectRatio
-{
-    GX2_ASPECT_RATIO_4_TO_3,
-    GX2_ASPECT_RATIO_16_TO_9
-}
-GX2AspectRatio;
-
 extern "C" GX2AspectRatio GX2GetSystemTVAspectRatio(void);
 
 static bool gfx_gx2_window_foreground_acquire_callback(void)
@@ -140,13 +133,13 @@ static bool gfx_gx2_window_foreground_acquire_callback(void)
         case GX2_TV_SCAN_MODE_576I:
         case GX2_TV_SCAN_MODE_480I:
         case GX2_TV_SCAN_MODE_480P:
-            if (tv_aspect_ratio == GX2_ASPECT_RATIO_4_TO_3)
+            if (tv_aspect_ratio == GX2_ASPECT_RATIO_4_3)
             {
                 g_window_width = 640;
                 g_window_height = 480;
                 tv_render_mode = GX2_TV_RENDER_MODE_STANDARD_480P;
             }
-            else // if (tv_aspect_ratio == GX2_ASPECT_RATIO_16_TO_9)
+            else // if (tv_aspect_ratio == GX2_ASPECT_RATIO_16_9)
             {
                 g_window_width = 854;
                 g_window_height = 480;

--- a/src/pc/ultra_reimplementation.c
+++ b/src/pc/ultra_reimplementation.c
@@ -77,7 +77,7 @@ void osViSetSpecialFeatures(UNUSED u32 func) {
 void osViSwapBuffer(UNUSED void *vaddr) {
 }
 
-OSTime osGetTime(void) {
+OSTime64 osGetTime(void) {
     struct timeval tv;
     gettimeofday(&tv, NULL);
     return (unsigned long)tv.tv_sec * 1000000 + tv.tv_usec;


### PR DESCRIPTION
This repo doesn't build on Wii U with the current toolchain for a few fairly minor reasons:
* WUT has its own `OSTime` variable which clashes with the `extern OSTime` in SM64
  * renamed the Mario 64-side variable to `OSTime64` to avoid collision
* `nunchuck` has been corrected to `nunchuk` in WUT
  * corrected this on the Mario side also
* the GX2 aspect ratio enums are already defined in WUT
  * remove them from Mario 64, use the WUT versions

I've also included a Dockerfile to make building the Wii U version easier and modified the `README.md` slightly with some simple instructions for doing this. I can undo these changes if you don't want this but it should be harmless and makes the complicated process of compiling Mario 64 for Wii U a bit more approachable.

I'm building with `devkitpro/devkitppc:20240702` (same version included in the Dockerfile), so this is current as of five days ago at time of PR.

**EDIT:** I just had a crash when collecting a star, marking as draft for now.
**EDIT2:** I can't repro this in the short term. For reference, the crash was in Dire, Dire Docks (submarine level). I was in the Pole-Jumping for Red Coins mission, collected all of the red coins, tested out all the various settings in the R-button menu, then collected the Collect the Caps star in the underwater cage. No Wii U crash log was generated.