### PR TITLE
redo mechanics of super speed cheat

### DIFF
--- a/src/extras/cheats.c
+++ b/src/extras/cheats.c
@@ -202,7 +202,7 @@ void cheats_mario_action(struct MarioState *m) {
 
         cheats_infinite_lives(m);
 
-        cheats_super_speed(m);
+        //cheats_super_speed(m);
 
         cheats_invincible_player(m);
     }

--- a/src/game/mario.c
+++ b/src/game/mario.c
@@ -867,6 +867,12 @@ static u32 set_mario_action_airborne(struct MarioState *m, u32 action, u32 actio
             if ((m->forwardVel *= 1.5f) > 48.0f) {
                 m->forwardVel = 48.0f;
             }
+
+#ifdef CHEATS_ACTIONS
+            if (Cheats.EnableCheats && Cheats.SuperSpeed) {
+                m->forwardVel *= 1.3f;
+            }
+#endif
             break;
 
         case ACT_SLIDE_KICK:

--- a/src/game/mario_actions_moving.c
+++ b/src/game/mario_actions_moving.c
@@ -505,6 +505,10 @@ void update_walking_speed(struct MarioState *m) {
     }
 
 #ifdef CHEATS_ACTIONS
+    if (Cheats.EnableCheats && Cheats.SuperSpeed) {
+        m->forwardVel *= 1.6f;
+    }
+
     if (Cheats.EnableCheats && Cheats.Responsive) {
         m->faceAngle[1] = m->intendedYaw;
     } else {


### PR DESCRIPTION
the current super speed cheat has very broken mechanics currently that makes it super unplayable. this pr changes that by only modifying the initial walking speed instead of increasing velocity every action frame (which starts to build up if you skid, jump, or really do any action besides walking).